### PR TITLE
Fix tergite version >2024.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 - Added the `nqrun` operation
 - Added BATS-enabled automated testing
-- Added access to QAL 9000 via tergite SDK
+- Added access to QAL 9000 via tergite SDK >2024.9.1
+    - Version 2024.9.1 might cause older but compatible versions qiskit_iqm to be installed.
+    - tergite contains qiskit. Installing another qiskit (e.g. an incomaptible version) might cause errors at runtime or during installation
 - Added access to Helmi via qiskit-iqm
 
 ### Changed

--- a/nordiquest
+++ b/nordiquest
@@ -111,7 +111,7 @@ set-function	nqrun {
         if [ -n "$requirements_file" ]; then
             pip install -r $requirements_file;
         else
-            pip install tergite qiskit-iqm qiskit;
+            pip install "tergite>=2024.9.1" qiskit-iqm;
         fi
     };
     function generate_bash_script () 

--- a/nordiquest.sh
+++ b/nordiquest.sh
@@ -193,7 +193,7 @@ function nqrun () {
       pip install -r $requirements_file;
     else
       # install the default required packages
-      pip install tergite qiskit-iqm qiskit;
+      pip install "tergite>=2024.9.1" qiskit-iqm;
     fi
 
   }

--- a/test/test_helper/fixtures/requirements.txt
+++ b/test/test_helper/fixtures/requirements.txt
@@ -1,3 +1,2 @@
-tergite
+tergite>=2024.9.1
 qiskit-iqm
-qiskit

--- a/test/test_helper/fixtures/sample.py
+++ b/test/test_helper/fixtures/sample.py
@@ -8,8 +8,12 @@ import tergite
 
 import qiskit
 
-# Don't remove this as it ensures qiskit-iqm is installed
-import qiskit_iqm
+try:
+    # Don't remove this as it ensures qiskit-iqm is installed
+    import qiskit_iqm
+except ModuleNotFoundError:
+    # Don't remove this as it ensures qiskit-iqm is installed
+    import iqm.qiskit_iqm
 
 print(sys.executable)
 print(f"QAL9000_API_URL: {os.environ.get('QAL9000_API_URL')}")


### PR DESCRIPTION
### Why
Tergite versions +v2024.9.1 have clear dependencies listed so that incompatibilities with other packages are automatically resolved by pip. It also comes with qiskit pre-installed. Attempting to install another qiskit (e.g. +1.0) will raise errors either at runtime or during installation.

We fix tergite to versions above v2024.9.1 for this reason.

**Note: this forces older versions of qiskit_iqm to be installed. This will change when tergite starts supporting qiskit +v1.0 in its next major release**

### What was done

- Fixed tergite version to `>=2024.9.1`
- Removed `qiskit` from requirements (in requirements.txt and as default requirements)