### PR TITLE
Add error message when python module is not available in compute node

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ git clone https://github.com/NordIQuEst/nordiquest-hpc-module.git
 
 ```shell
 cd nordiquest-hpc-module
-mkdir -p /global/D1/homes/YOUR_USERNAME/modulefiles
-cp nordiquest /global/D1/homes/YOUR_USERNAME/modulefiles/nordiquest
-module use --append /global/D1/homes/YOUR_USERNAME/modulefiles
+mkdir -p /global/D1/homes/$(whoami)/modulefiles
+cp nordiquest /global/D1/homes/$(whoami)/modulefiles/nordiquest
+module use --append /global/D1/homes/$(whoami)/modulefiles
 ```
-
-**Note: Replace `YOUR_USERNAME` with your username**
 
 **One other option is to install the module in a projects folder so that it is accessible for multiple users. Contact <ex3-helpdesk@simula.no>**
 
@@ -123,7 +121,7 @@ nqrun \
   quantum_example.py
 ```
 
-**Dont forget to update `YOUR_USERNAME` to your ex3 username**
+**Note that the python module you pass must also exist in the compute module or else it will fail**
 
 - Enter the QAL 9000 API token when it requests for one and wait for the job complete
 
@@ -168,6 +166,27 @@ git clone --recurse-submodules https://github.com/NordIQuEst/nordiquest-hpc-modu
 cd nordiquest-hpc-module
 module sh-to-mod bash nordiquest.sh >nordiquest
 ```
+
+## Frequently asked questions
+
+
+- ### How do I check that the python module I want exists in the compute node?
+
+To check if a module is available in the compute module:
+
+Enter the compute node.    
+
+```shell
+# enter the compute node e.g. armq
+srun -p armq -N 1 -n 256 --pty /bin/bash
+```
+
+List the available python modules. Does your module appear in the list?
+
+```shell
+module avail python
+```
+
 
 ## Authors
 

--- a/nordiquest
+++ b/nordiquest
@@ -107,11 +107,10 @@ set-function	nqrun {
             module load $python_module;
         fi;
         python -m venv "$python_env";
-        source "$python_env/bin/activate";
         if [ -n "$requirements_file" ]; then
-            pip install -r $requirements_file;
+            "$python_env/bin/pip" install -r $requirements_file;
         else
-            pip install "tergite>=2024.9.1" qiskit-iqm;
+            "$python_env/bin/pip" install "tergite>=2024.9.1" qiskit-iqm;
         fi
     };
     function generate_bash_script () 
@@ -121,6 +120,9 @@ set-function	nqrun {
         do
             echo "export $env_var;" >> $bash_script;
         done;
+        echo "source $python_env/bin/activate" >> $bash_script;
+        no_python_msg="no python available, probably the compute node does not have module $python_module.";
+        echo "if [[ \"\$(which python)\" == *$python_env/bin/python ]]; then echo 'virtual env activated.'; else echo '$no_python_msg'; exit 1; fi" >> $bash_script;
         echo "python $py_script_path;" >> $bash_script;
         for env_pair in "${env_vars[@]}";
         do
@@ -134,7 +136,10 @@ set-function	nqrun {
             rm -r "$python_env";
             echo "";
         fi;
-        rm $bash_script
+        rm $bash_script;
+        if [ -n "$python_module" ]; then
+            module unload $python_module;
+        fi
     };
     prepare_python_env;
     generate_bash_script;

--- a/nordiquest.sh
+++ b/nordiquest.sh
@@ -184,16 +184,15 @@ function nqrun () {
       module load $python_module;
     fi
 
-    # creating and activate virtual environment
+    # creating virtual environment
     python -m venv "$python_env";
-    source "$python_env/bin/activate";
 
     # installing packages in python virtual environment
     if [ -n "$requirements_file" ]; then
-      pip install -r $requirements_file;
+      "$python_env/bin/pip" install -r $requirements_file;
     else
       # install the default required packages
-      pip install "tergite>=2024.9.1" qiskit-iqm;
+      "$python_env/bin/pip" install "tergite>=2024.9.1" qiskit-iqm;
     fi
 
   }
@@ -207,6 +206,12 @@ function nqrun () {
     for env_var in "${env_vars[@]}"; do
       echo "export $env_var;" >> $bash_script;
     done
+
+    # activate the environment
+    echo "source $python_env/bin/activate" >> $bash_script;
+
+    no_python_msg="no python available, probably the compute node does not have module $python_module."
+    echo "if [[ \"\$(which python)\" == *$python_env/bin/python ]]; then echo 'virtual env activated.'; else echo '$no_python_msg'; exit 1; fi" >> $bash_script;
 
     # running python script
     echo "python $py_script_path;" >> $bash_script;
@@ -228,6 +233,11 @@ function nqrun () {
     
     # deleting bash script after?
     rm $bash_script;
+
+    # unload the python module
+    if [ -n "$python_module" ]; then
+      module unload $python_module;
+    fi
   }
 
   # Run

--- a/test/test_helper/mocks.sh
+++ b/test/test_helper/mocks.sh
@@ -52,6 +52,11 @@ function module () {
         echo "$2 module loaded";
         return 0
         ;;
+      unload)
+        echo "$2 module unloaded";
+        return 0
+        ;;
     esac
   done
 }
+


### PR DESCRIPTION
### Why

When a python module that is not present in the compute node is passed, it was originally giving a cryptic error 'line 6: python: command not found'.

Fixes #3 

### What was done

- Added an error message when the python module is not found in the compute node
- Added instructions on how to check if a python module is available in the compute node
